### PR TITLE
#164114852 (Fix) Allow webpack to access environment variable on remote server

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -51,7 +51,7 @@ const socialMediaLoginIcons = [
     url: process.env.TWITTER_URL
   }
 ];
-const API_BASE_URL = 'https://krypton-ah-stage.herokuapp.com';
+
 const authentication = 'authentication';
 const twitterPath = '/auth/twitter/callback';
 
@@ -60,7 +60,6 @@ export {
   articleDetails,
   advertimage,
   socialMediaLoginIcons,
-  API_BASE_URL,
   authentication,
   twitterPath
 };

--- a/src/helpers/axiosHelper/auth.js
+++ b/src/helpers/axiosHelper/auth.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { API_BASE_URL } from '../../constants';
+
+const { API_BASE_URL } = process.env;
 
 const hostURL = `${API_BASE_URL}/api/v1`;
 

--- a/src/helpers/axiosHelper/verifySocialAuth.js
+++ b/src/helpers/axiosHelper/verifySocialAuth.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { API_BASE_URL } from '../../constants';
+
+const { API_BASE_URL } = process.env;
 
 /**
   * @description makes social media authentication axios request

--- a/src/mockData/index.js
+++ b/src/mockData/index.js
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../constants';
+const { API_BASE_URL } = process.env;
 
 const items = [
   {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   entry: {
@@ -54,7 +53,6 @@ module.exports = {
     historyApiFallback: true
   },
   plugins: [
-    new Dotenv(),
     new HtmlWebpackPlugin({
       title: 'Authors Haven',
       template: './index.html'

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,5 +1,6 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const Dotenv = require('dotenv-webpack');
 
 module.exports = merge(common, {
   mode: 'development',
@@ -8,5 +9,8 @@ module.exports = merge(common, {
     host: 'localhost',
     port: process.env.PORT || 5000,
     contentBase: './dist'
-  }
+  },
+  plugins: [
+    new Dotenv()
+  ]
 });

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -1,6 +1,21 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const dotenv = require('dotenv');
+const webpack = require('webpack');
 
+dotenv.config();
 module.exports = merge(common, {
-  mode: 'production'
+  mode: 'production',
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+        FACEBOOK_URL: JSON.stringify(process.env.FACEBOOK_URL),
+        GOOGLE_URL: JSON.stringify(process.env.GOOGLE_URL),
+        LINKEDIN_URL: JSON.stringify(process.env.LINKEDIN_URL),
+        TWITTER_URL: JSON.stringify(process.env.TWITTER_URL),
+        API_BASE_URL: JSON.stringify(process.env.API_BASE_URL)
+      }
+    })
+  ]
 });


### PR DESCRIPTION
#### What does this PR do
Allow webpack to access environment variable on remote server when building

#### Description of Task to be completed?
- Edit webpack config
- install dotenv
- add environment variables to webpack production

#### What are the relevant pivotal tracker stories?
PT Link: https://www.pivotaltracker.com/story/show/164114852